### PR TITLE
Bugfix: `_id` doesn't serialize to `id`

### DIFF
--- a/Models/MessageOfTheDayItem.cs
+++ b/Models/MessageOfTheDayItem.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -13,7 +14,8 @@ public class MessageOfTheDayItem
     /// </summary>
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
-    public required string Id { get; set; }
+    [JsonPropertyName("_id")]
+    public string Id { get; set; } = null!;
 
     /// <summary>
     /// The actual message text contained in this MOTD.


### PR DESCRIPTION
Fixes a bug where the id field on an MOTD would serialize to `id` rather than `_id`.