### PR TITLE
Bugfix: Wrong HTTP Method in Update MOTD Route

### DIFF
--- a/Controllers/MessageOfTheDayController.cs
+++ b/Controllers/MessageOfTheDayController.cs
@@ -73,7 +73,7 @@ namespace MotdApiDotnet.Controllers
         }
 
         // PATCH: /6663730d73d66868453f5990
-        [HttpPost("{id}")]
+        [HttpPatch("{id}")]
         public async Task<ActionResult<MessageOfTheDayItem>> PatchMotd(string id, string message)
         {
             // TODO - we need a better patch function on the service


### PR DESCRIPTION
Fixes a bug where the Update MOTD route was using POST instead of PATCH.